### PR TITLE
Convert deprecated alias_method_chain to Module#prepend

### DIFF
--- a/lib/fast_context.rb
+++ b/lib/fast_context.rb
@@ -1,5 +1,7 @@
 require 'shoulda/context'
 
+
+
 module ShouldaContextExtensions
   def fast_context(name, &blk)
     @fast_subcontexts ||= []
@@ -46,8 +48,8 @@ module Shoulda
           context.run_current_setup_blocks(self)
 
           context.shoulds.each {|should| should[:block].bind(self).call }
-        rescue Test::Unit::AssertionFailedError => e
-          error = Test::Unit::AssertionFailedError.new(["FAILED:", context.full_name, "should", "#{@current_should[:name]}:", e.message].flatten.join(' '))
+        rescue ActiveSupport::TestCase::Assertion => e
+          error = ActiveSupport::TestCase::Assertion.new(["FAILED:", context.full_name, "should", "#{@current_should[:name]}:", e.message].flatten.join(' '))
           error.set_backtrace e.backtrace
           raise error
         ensure

--- a/lib/fast_context.rb
+++ b/lib/fast_context.rb
@@ -1,25 +1,18 @@
 require 'shoulda/context'
 
 module ShouldaContextExtensions
-  def self.included(base)
-    base.class_eval do
-      alias_method_chain :build, :fast_context
-      alias_method_chain :am_subcontext?, :fast_context
-    end
-  end
-
   def fast_context(name, &blk)
     @fast_subcontexts ||= []
     @fast_subcontexts << Shoulda::FastContext.new(name, self, &blk)
   end
 
-  def build_with_fast_context
-    build_without_fast_context
+  def build
+    super
     @fast_subcontexts ||= []
     @fast_subcontexts.each {|f| f.build }
   end
 
-  def am_subcontext_with_fast_context?
+  def am_subcontext?
     parent.is_a?(Shoulda::Context::Context) || parent.is_a?(Shoulda::FastContext)
   end
 end
@@ -86,4 +79,4 @@ class ActiveSupport::TestCase
   end
 end
 
-Shoulda::Context::Context.send :include, ShouldaContextExtensions
+Shoulda::Context::Context.prepend ShouldaContextExtensions


### PR DESCRIPTION
Requires Ruby >= 2.0; removes deprecation notices with Rails 5
